### PR TITLE
make code reuse httpclienthandler, and make processing of sending logs parallel

### DIFF
--- a/src/Elmah.Io.AspNetCore/ElmahIoExtensions.cs
+++ b/src/Elmah.Io.AspNetCore/ElmahIoExtensions.cs
@@ -14,7 +14,9 @@ namespace Elmah.Io.AspNetCore
         public static IServiceCollection AddElmahIo(this IServiceCollection services, Action<ElmahIoOptions> configureOptions)
         {
             services.AddHostedService<QueuedHostedService>();
+            services.AddHostedService<OtherQueuedHostedService>();
             services.AddSingleton<IBackgroundTaskQueue, BackgroundTaskQueue>();
+            services.AddSingleton<IOtherBackgroundTaskQueue, OtherBackgroundTaskQueue>();
             services.Configure(configureOptions);
             return services;
         }

--- a/src/Elmah.Io.AspNetCore/HttpClientHandlerFactory.cs
+++ b/src/Elmah.Io.AspNetCore/HttpClientHandlerFactory.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Net.Http;
+
+namespace Elmah.Io.AspNetCore
+{
+    internal static class HttpClientHandlerFactory
+    {
+        private static HttpClientHandler _instance = null;
+        private static DateTime _initTime = DateTime.MinValue;
+        private static TimeSpan _lifeTime = TimeSpan.FromHours(24);
+
+        public static HttpClientHandler GetHttpClientHandler(ElmahIoOptions options)
+        {            
+            if (DateTime.Now.Subtract(_initTime) > _lifeTime || _instance == null)
+            {
+                _instance = new HttpClientHandler
+                {
+                    UseProxy = options.WebProxy != null,
+                    Proxy = options.WebProxy,
+                };
+                _initTime = DateTime.Now;
+            }
+            return _instance;
+        }
+    }
+}

--- a/src/Elmah.Io.AspNetCore/IBackgroundTaskQueue.cs
+++ b/src/Elmah.Io.AspNetCore/IBackgroundTaskQueue.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,8 +9,7 @@ namespace Elmah.Io.AspNetCore
     {
         void QueueBackgroundWorkItem(Func<CancellationToken, Task> workItem);
 
-        Task<Func<CancellationToken, Task>> DequeueAsync(
-            CancellationToken cancellationToken);
+        Task<Func<CancellationToken, Task>> DequeueAsync(CancellationToken cancellationToken);
     }
 
     public class BackgroundTaskQueue : IBackgroundTaskQueue

--- a/src/Elmah.Io.AspNetCore/IOtherBackgroundTaskQueue.cs
+++ b/src/Elmah.Io.AspNetCore/IOtherBackgroundTaskQueue.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elmah.Io.AspNetCore
+{
+    public interface IOtherBackgroundTaskQueue
+    {
+        void QueueBackgroundWorkItem(Task workItem);
+
+        Task DequeueAsync(CancellationToken cancellationToken);
+    }
+
+    public class OtherBackgroundTaskQueue : IOtherBackgroundTaskQueue
+    {
+        private readonly BlockingCollection<Task> _initiatedQueue = new BlockingCollection<Task>();
+
+        public void QueueBackgroundWorkItem(Task workItem)
+        {
+            if (workItem == null)
+            {
+                throw new ArgumentNullException(nameof(workItem));
+            }
+
+            _initiatedQueue.Add(workItem);
+        }
+
+        public Task DequeueAsync(CancellationToken cancellationToken)
+        {
+            return _initiatedQueue.Take();
+        }
+    }
+}

--- a/src/Elmah.Io.AspNetCore/OtherQueuedHostedService.cs
+++ b/src/Elmah.Io.AspNetCore/OtherQueuedHostedService.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elmah.Io.AspNetCore
+{
+    public class OtherQueuedHostedService : BackgroundService
+    {
+        private readonly IOtherBackgroundTaskQueue _taskQueue;
+        public OtherQueuedHostedService(IOtherBackgroundTaskQueue taskQueue)
+        {
+            _taskQueue = taskQueue;
+        }
+
+        protected async override Task ExecuteAsync(
+            CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var t = _taskQueue.DequeueAsync(cancellationToken);
+                    await t;
+                }
+                catch (Exception ex)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/Elmah.Io.AspNetCore/QueuedHostedService.cs
+++ b/src/Elmah.Io.AspNetCore/QueuedHostedService.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.Hosting;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,23 +7,27 @@ namespace Elmah.Io.AspNetCore
 {
     public class QueuedHostedService : BackgroundService
     {
-        public QueuedHostedService(IBackgroundTaskQueue taskQueue)
-        {
-            TaskQueue = taskQueue;
-        }
+        private readonly IBackgroundTaskQueue _taskQueue;
+        private readonly IOtherBackgroundTaskQueue otherBackgroundTaskQueue;
 
-        public IBackgroundTaskQueue TaskQueue { get; }
+        public QueuedHostedService(IBackgroundTaskQueue taskQueue, IOtherBackgroundTaskQueue otherBackgroundTaskQueue)
+        {
+            _taskQueue = taskQueue;
+            this.otherBackgroundTaskQueue = otherBackgroundTaskQueue;
+        }        
 
         protected async override Task ExecuteAsync(
             CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var workItem = await TaskQueue.DequeueAsync(cancellationToken);
+
+                var workItem = await _taskQueue.DequeueAsync(cancellationToken);
 
                 try
                 {
-                    await workItem(cancellationToken);
+                    var blah = workItem(cancellationToken);
+                    otherBackgroundTaskQueue.QueueBackgroundWorkItem(blah);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
- Extremely simple reuse of httpclienthandler.. caches for 24h. Makes dns cache updated come through, but keeps port usage low.. Next step for this would be to use httpclientfactory, but that doesnt work with ServiceClient and autorest.. So would need to create your own managed client or use e.g. https://github.com/reactiveui/refit

- Starts tasks in background for sending logs in one thread, and awaits them in a different thread.. essentially allowing many parallel httprequests (as many as one thread can spawn.. not perfectly concurrent, but if you have that many errrors you are probably in big dodo). There seems to be coming some good stuff on this from aspnetcore in the future, so I think this will do fine until then:
https://github.com/aspnet/Extensions/issues/805



